### PR TITLE
add nginx simple location for catch bad IP's

### DIFF
--- a/nginx-phish.conf
+++ b/nginx-phish.conf
@@ -1,0 +1,7 @@
+...
+        location /blog {
+                log_format		ip-only	'$time_local - $remote_addr';
+                access_log		/var/log/nginx/govip.log ip-only;
+				        return 404;
+        }
+...


### PR DESCRIPTION
Специальная ссылка для сбора нежелательных IP, при переходе nginx всегда возвращает 404.
Размещаем на сервере.
Жалуемся куда следует на ссылку вида: http[s]://yousite.ru/blog/some_any_text_here
В отдельном логе видим IP.
